### PR TITLE
limit to paginated requests

### DIFF
--- a/src/sayari/__init__.py
+++ b/src/sayari/__init__.py
@@ -177,7 +177,7 @@ def get_all_data(func, *args, **kwargs):
     resp = func(*args, **kwargs)
     if hasattr(resp, 'size') and resp.size.count >= max_results:
         raise err_too_much_data_requested
-    if not hasattr(resp.next):
+    if not hasattr(resp, 'next'):
         raise err_function_not_paginated
     all_data = resp.data
     while resp.next:


### PR DESCRIPTION
only allow paginated functions to use the 'get_all_data' function.

This relies on the assumption that all paginated bodies contain a 'next' field in their response.