### PR TITLE
revert logic while maintaining updated structure

### DIFF
--- a/examples/trade-search.py
+++ b/examples/trade-search.py
@@ -15,35 +15,17 @@ def main():
     # Load environment variables and authenticate
     client = load_env_vars_and_authenticate(env)
 
-    resolution = client.resolution.resolution(name="microcenter")
-    entity_details = client.entity.get_entity(resolution.data[0].entity_id)
-    print(
-        f"**********************************************************************\n"
-        f"Name of Company : {entity_details.label}\n"               # Display the company name
-        f"Address         : {entity_details.addresses}\n"           # Display the company address
-        f"Company Type    : {entity_details.company_type}\n"        # Display the company type
-        f"**********************************************************************"
-    )
+    # Search for shipments
+    shipments = client.trade.search_shipments(q="microcenter")
+    print("Found", len(shipments.data), "shipments.")
 
-    # Define the search queries and corresponding entity names.
-    # Each tuple in `queries` consists of:
-    # 1. A search call using `client.trade` API for different entities (shipments, suppliers, buyers).
-    # 2. A string that represents the entity name, which is used to label the search result.
+    # Search for suppliers
+    suppliers = client.trade.search_suppliers(q="microcenter")
+    print("Found", len(suppliers.data), "suppliers.")
 
-    queries = [
-        (client.trade.search_shipments(q="microcenter"), "shipments"),  # Search for shipments containing 'microcenter'
-        (client.trade.search_suppliers(q="microcenter"), "suppliers"),  # Search for suppliers containing 'microcenter'
-        (client.trade.search_buyers(q="microcenter"), "buyers"),        # Search for buyers containing 'microcenter'
-    ]
-
-    # Loop through each entity search, process the search results, and print the count.
-    # `entity` represents the search result object, and `search_type` is the name label.
-
-    for entity, search_type in queries:
-        # `entity.data` holds the list of results for each query (e.g., all shipments matching "microcenter")
-        # Print the total count of found entities for each search_type (shipments, suppliers, or buyers).
-        print(f"Found {len(entity.data)} {search_type}.")
-
+    # Search for buyers
+    buyers = client.trade.search_buyers(q="microcenter")
+    print("Found", len(buyers.data), "buyers.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
While the updated trade search example looked a lot better, there was an issue with the logic where it assumed the first resolved entity for a search term would necessarily related to the same search term used for trade searches. While not an unreasonable assumption, it is incorrect. Consider the example where we search for companies with the name 'electronics' and then search for shipments with a search term 'electronics' they may overlap, but cannot be considered to related 1:1