### PR TITLE
chore: supply-chain hardening — lockfile enforcement + action SHA pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.11
 
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies including python-dotenv
         run: |
-          poetry install
+          poetry install --no-update
 
       - name: Run Mypy with ignore missing imports
         run: poetry run mypy --ignore-missing-imports .
@@ -33,24 +33,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.11
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --no-update
       - name: Test
         run: poetry run pytest . -v
   run-examples:
     name: Run examples (to look for regressions)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: test examples (not rate limiting)
@@ -78,16 +78,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.11
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --no-update
       - name: Update pyproject.toml
         run: |
           sed 's/description = ""/description = "A Python SDK for Sayari"/g' pyproject.toml > tmp_pyproject

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "pip_requirements",
+        "poetry",
+        "pipenv",
+        "uv"
+      ],
+      "minimumReleaseAge": "7 days",
+      "description": "Supply-chain hardening: 7-day cooldown for all PyPI packages"
+    }
+  ]
+}


### PR DESCRIPTION
## Supply Chain Hardening

Automated supply-chain security controls applied by `supply-chain-pr.py`.

### Changes made

- **`ci.yml`**: SHA-pinned 2 actions to full commit hash

### Python ecosystem changes

- **`renovate.json`**: Added `minimumReleaseAge: "7 days"` for all PyPI package managers (`pip_requirements`, `poetry`, `uv`, `pipenv`) — Renovate will not merge a PyPI update until the release is 7 days old
- **`ci.yml`**: poetry install → poetry install --no-update (3×)

> **`poetry install --no-update`** prevents implicit dependency updates during CI installs. The `renovate.json` cooldown ensures new PyPI releases are not picked up until 7 days after publish.

### Why these controls

| Control | Threat mitigated |
|---------|-----------------|
| Action SHA pins | Prevents tag-hijack (ref: aquasecurity/trivy-action, Mar 2026) |
| `UV_EXCLUDE_NEWER` / `renovate.json` cooldown | 7-day PyPI cooldown prevents same-day version compromise |
| `uv sync --frozen` / `poetry install --no-update` | CI installs exact lockfile versions — no silent drift |

### Testing checklist

- [ ] CI passes on this branch (green)
- [ ] Python install/sync step succeeds with no version changes

---
*Generated by `supply-chain-pr.py` — part of the dependency-security-policy rollout.*